### PR TITLE
删除 Codec 自定义初始化方法中，对 `Codable` 的要求

### DIFF
--- a/Sources/CodableWrapper/CodecInit.swift
+++ b/Sources/CodableWrapper/CodecInit.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public extension Codec where Value: Codable {
+public extension Codec {
     ///
     /// ```
     /// @Codec var uid: String?


### PR DESCRIPTION
对于一些只要求 `Decodable` 或者 `Encodable` 的 model，现在的版本无法使用 `init(wrappedValue:, _: ..., noNested:)` 方法初始化 `Codec`。

但是阅读源码，发现这个初始化方法其实并没有什么一定要实现 `Codable` 的原因？感觉删除了也是可以的。