### PR TITLE
为 `Codec` 添加 `Hashable`

### DIFF
--- a/Sources/CodableWrapper/Codec.swift
+++ b/Sources/CodableWrapper/Codec.swift
@@ -51,3 +51,7 @@ extension Codec: CustomStringConvertible, CustomDebugStringConvertible {
         "\(wrappedValue)"
     }
 }
+
+extension Codec: Equatable where Value: Equatable { }
+
+extension Codec: Hashable where Value: Hashable { }


### PR DESCRIPTION
有一些框架（例如[Epoxy](https://github.com/airbnb/epoxy-ios)）会要求 Model 遵循 `Hashable` 协议，而 `Codec` 如果能遵循 `Hashable` 协议的话，对于整个 Model 遵循 `Hashable` 有很大的帮助，而且实现起来也十分简单。