### PR TITLE
修复xcode 16不识别Cocoapods导入的宏定义的问题

### DIFF
--- a/CodableWrapper.podspec
+++ b/CodableWrapper.podspec
@@ -25,11 +25,11 @@ Pod::Spec.new do |s|
   s.preserve_paths = ["Package.swift", "Sources/CodableWrapperMacros", "Tests", "Bin"]
   
   s.pod_target_xcconfig = {
-    "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/CodableWrapper/release/CodableWrapperMacros#CodableWrapperMacros"
+    "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/CodableWrapper/release/CodableWrapperMacros-tool#CodableWrapperMacros"
   }
   
   s.user_target_xcconfig = {
-    "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/CodableWrapper/release/CodableWrapperMacros#CodableWrapperMacros"
+    "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/CodableWrapper/release/CodableWrapperMacros-tool#CodableWrapperMacros"
   }
 
   script = <<-SCRIPT


### PR DESCRIPTION
主要原因在于Xcode16对于swift build生成的二进制名称进行了修改，增加了-tool导致不识别（服了，没事喜欢瞎改名）。暂时没有找到swift build指定生成的二进制名称的方式，解决的方法是将Podfile和podspec中的CodableWrapperMacros#CodableWrapperMacros改为CodableWrapperMacros-tool#CodableWrapperMacros